### PR TITLE
Heila feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,22 @@ UPDATE users SET is_banned = true WHERE uuid='D47DA01C-51BB-4F96-90B6-D64B77225E
 * Token authentication is required. Token is sent in `x-token` header.
 
 
+
+
+
+### `GET /api/heila`
+
+> List heila profiles
+
+Query parameters:
+
+* Nothing implemented yet. The query returns full list of all heilas.
+
+Responses:
+
+* `200 OK` List of [heila objects](#heila-object).
+
+
 ### `GET /api/events`
 
 > List events
@@ -401,6 +417,20 @@ Responses:
 * `200 OK` Body is one of [radio objects](#radio-object).
 
 ## Response objects
+
+### Heila object
+
+```js
+{
+  "id": 2002,
+  "name": "Pate Papparainen",
+  "team_id": 1,
+  "image_url": "https://..." | "", // if no image, then ""
+  "bio_text": "I'm very nice",
+  "bio_looking_for": "Very nice!"
+}
+
+```
 
 ### Event object
 

--- a/src/core/heila-core.js
+++ b/src/core/heila-core.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import * as feedCore from './feed-core.js';
+import { prefixImageWithGCS } from './image-core.js'
 import { GCS_CONFIG } from '../util/gcs';
 const BPromise = require('bluebird');
 const {knex} = require('../util/database').connect();
@@ -59,6 +60,44 @@ function findByUuid(uuid) {
 
       return _heilaRowToObject(rows[0]);
     });
+}
+
+function getAllHeilas() {
+  console.log('getAllHeilas');
+
+  // palauttaa listan, jossa tällaisia objekteja:
+  // { id: string, name: string, image_url: string,
+  //   team_id: int, bio_text: string, bio_looking_for: string }
+
+  return knex('users')
+    .select('users.*')
+    .where({ heila: true })
+    .then(rows => {
+      if (_.isEmpty(rows)) {
+        return [];
+      }
+      return _heilaRowsToObjectList(rows);
+    })
+}
+
+function _heilaRowsToObjectList(userList) {
+
+  // userList sisältää _VAIN_ heila: true -tyyppisiä profiileja
+
+  const heilaList = userList
+    .map(user => {
+      return {
+        id: user.id,
+        name: user.name,
+        team_id: user.team_id,
+        image_url: prefixImageWithGCS(user.image_path),
+        bio_text: "lorem ipsum bibibibibi",
+        bio_looking_for: "something nice"
+      }
+    })
+  console.log("heilaList")
+  console.log(heilaList)
+  return heilaList;
 }
 
 /**
@@ -158,5 +197,6 @@ function _heilaRowToObject(row) {
 export {
   createOrUpdateHeila,
   findByUuid,
-  getHeilaDetails
+  getHeilaDetails,
+  getAllHeilas,
 };

--- a/src/core/image-core.js
+++ b/src/core/image-core.js
@@ -63,6 +63,9 @@ function _rowToImage(row) {
 }
 
 function prefixImageWithGCS(imagePath) {
+  if (imagePath === "") {
+    return "";
+  }
   if (process.env.DISABLE_IMGIX === 'true' || _.endsWith(imagePath, 'gif')) {
     return GCS_CONFIG.baseUrl + '/' + GCS_CONFIG.bucketName + '/' + imagePath;
   } else {

--- a/src/http/heila-http.js
+++ b/src/http/heila-http.js
@@ -13,11 +13,13 @@ const putHeila = createJsonRoute(function(req, res) {
 });
 
 // TODO: ei futaa
-const getHeilas = createJsonRoute(function(req, res) {
-  console.log('getHeilas FIX ME')
-  return new Promise();
+const getHeilaList = createJsonRoute(function(req, res) {
+  console.log('getHeilaList')
+  return heilaCore.getAllHeilas()
+    .then(heilaList => {
+      return heilaList;
+    })
 });
-
 
 const getHeilaByUuid = createJsonRoute(function(req, res) {
   return heilaCore.findByUuid(req.params.uuid)
@@ -31,8 +33,6 @@ const getHeilaByUuid = createJsonRoute(function(req, res) {
     return heila;
   });
 });
-
-
 
 // TODO: onko tarve
 const getUserById = createJsonRoute(function(req, res) {
@@ -56,6 +56,6 @@ const getUserById = createJsonRoute(function(req, res) {
 
 export {
   putHeila,
-  getHeilas,
+  getHeilaList,
   getHeilaByUuid,
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -18,11 +18,11 @@ function createRouter() {
   const router = express.Router();
 
   // palauttaa listan heiloja, joita voi frontissa näyttää heilanselauksessa
-  router.get('/heila', heilaHttp.getHeilas);
+  router.get('/heila', heilaHttp.getHeilaList);
   // palauttaa yhden heilan tiedot (käytännössä ne samat tiedot, joita ylempi palauttaa listassa)
-  router.get('/heila/:uuid', heilaHttp.getHeilaByUuid);
+  // router.get('/heila/:uuid', heilaHttp.getHeilaByUuid);
   // päivittää oman heilaprofiilin tekstikenttätietoja
-  router.put('/heila/:uuid', heilaHttp.putHeila);
+  // router.put('/heila/:uuid', heilaHttp.putHeila);
 
   router.get('/events', eventHttp.getEvents);
   router.get('/events/:id', eventHttp.getEvent);


### PR DESCRIPTION
This PR adds a new endpoint that listens for GET requests at /api/heila

* it returns a list of heila profile objects
* heila profile objects are documented in the README of the repository
* it does NOT accept any query parameters as of now, it returns _every single muthafucin' heila_

This PR also disables endpoints /api/heila/:uuid for both GET and PUT since they were not doing anything else than **räpellys** and were not documented anywhere. I'll get back to them at a later time.