### PR TITLE
Close chat

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -28,6 +28,10 @@ export REDIS_URL=redis://wappu:wappu@127.0.0.1:2345
 # avain itse voi olla mitä vain
 export FUNCTION_SECRET_KEY=
 
+# tämä on funktioiden urli, jotakin tyyliin
+# https://-...cloudfunctions.net
+# saa firebase-konsolista ulos
+export FUNCTION_BASE_URL=
 
 # tämä tarkoittaa, että latata GCS-konffi kokonaan alla olevista
 # muuttujista; jos tähän laittaa false, niin GCS-konffi ladataan

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Responses:
 
 > This POSTs a match telling that "this user made an UP for that user"
 
+* Body is [match object](#match-object).
+
 Responses:
 * `200 OK`
 
@@ -208,6 +210,15 @@ Responses:
 * `200 OK` List of [match objects](#match-object).
 
 
+### `POST /api/heila/matches/close`
+
+> This POSTs a note that this particular chat should be CLOSED.
+This will disable writing to that Firebase chat.
+
+* Body is [match object close](#match-object-close).
+
+Responses:
+* `200 OK`
 
 
 
@@ -474,6 +485,16 @@ When you're GETting your own list of matches:
 {
   NOT DECIDED YET BUT IS ALREADY RETURNING:
   "firebaseChatId": "key that points to /chats/*** in firebase"
+}
+```
+
+### Match object close
+
+```js
+{
+  "uuid": "this is your own uuid",
+  "matchedUserId": "this is the USERID of the user you're closing the chat with",
+  "firebaseChatId": "this is the firebaseChatId your chat is located at"
 }
 ```
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -143,6 +143,8 @@ exports.sendPushMessage = functions.database.ref('/chats/{chatId}/')
     })
   });
 
+// this writes "closed": true to chats/chatId and so closes the chat
+// for writing. reading will still be allowed.
 exports.closeChatId = functions.https.onRequest((req, res) => {
   
   if (req.get('FUNCTION_SECRET_KEY') !== functions.config().functions.secret) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -143,3 +143,23 @@ exports.sendPushMessage = functions.database.ref('/chats/{chatId}/')
     })
   });
 
+exports.closeChatId = functions.https.onRequest((req, res) => {
+  
+  if (req.get('FUNCTION_SECRET_KEY') !== functions.config().functions.secret) {
+    console.log('not authenticated, FUNCTION_SECRET_KEY header is barps');
+    res.sendStatus(403);
+    return;
+  }
+
+  console.log(req.query)
+  const chatId = req.query.chatId;
+  
+  return admin.database().ref(`/chats/${chatId}`)
+    .update({
+      "closed": true
+    })
+    .then(r => {
+      res.sendStatus(200); 
+    })
+});
+

--- a/src/core/function-core.js
+++ b/src/core/function-core.js
@@ -1,7 +1,7 @@
 const process = require('process');
 const fetch = require('node-fetch');
 
-const BASE_URL = "https://us-central1-whappu-183808.cloudfunctions.net";
+const BASE_URL = process.env.FUNCTION_BASE_URL;
 
 function createChatForTwoUsers(matchRow) {
   console.log('createChatForTwoUsers');

--- a/src/core/function-core.js
+++ b/src/core/function-core.js
@@ -1,12 +1,11 @@
 const process = require('process');
 const fetch = require('node-fetch');
 
-const URL_CREATE_CHAT = "https://us-central1-whappu-183808.cloudfunctions.net/addNewChatBetweenUsers";
-const URL_ADD_PUSHTOKEN = "https://us-central1-whappu-183808.cloudfunctions.net/addPushTokenForUserId";
+const BASE_URL = "https://us-central1-whappu-183808.cloudfunctions.net";
 
 function createChatForTwoUsers(matchRow) {
   console.log('createChatForTwoUsers');
-  const current_url = `${URL_CREATE_CHAT}?userId1=${matchRow.userId1}&userId2=${matchRow.userId2}`;
+  const current_url = `${BASE_URL}/addNewChatBetweenUsers?userId1=${matchRow.userId1}&userId2=${matchRow.userId2}`;
   console.log(current_url);
   return fetch(current_url, {
     method: 'GET',
@@ -23,7 +22,23 @@ function createChatForTwoUsers(matchRow) {
 
 function addPushNotificationTokenForUserId(userId, pushToken) {
   console.log('addPushNotificationTokenForUserId');
-  const current_url = `${URL_ADD_PUSHTOKEN}?userId=${userId}&pushToken=${pushToken}`;
+  const current_url = `${BASE_URL}/addPushTokenForUserId?userId=${userId}&pushToken=${pushToken}`;
+  console.log(current_url);
+  return fetch(current_url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'FUNCTION_SECRET_KEY': process.env.FUNCTION_SECRET_KEY
+    }
+  })
+  .catch(err => {
+    console.log(err);
+  })
+};
+
+function closeChatId(chatId) {
+  console.log('closeChatId');
+  const current_url = `${BASE_URL}/closeChatId?chatId=${chatId}`;
   console.log(current_url);
   return fetch(current_url, {
     method: 'GET',

--- a/src/core/match-core.js
+++ b/src/core/match-core.js
@@ -158,7 +158,28 @@ function getListOfMatches(uuid) {
     })
 };
 
+function closeMatch(close) {
+  
+  return _uuidToUserId(close.uuid)
+    .then(closerUserId => {
+      return knex('matches')
+        .select('matches.*')
+        .where({
+          'userId1': (closerUserId < close.matchedUserId) ? closerUserId : close.matchedUserId,
+          'userId2': (closerUserId < close.matchedUserId) ? close.matchedUserId : closerUserId,
+          'firebaseChatId': close.firebaseChatId
+        })
+        .then(rows => {
+          if (rows.length === 1) {
+            functionCore.closeChat(close.firebaseChatId);            
+          }
+        })
+
+    })
+};
+
 export {
   createOrUpdateMatch,
   getListOfMatches,
+  closeMatch,
 }

--- a/src/core/match-core.js
+++ b/src/core/match-core.js
@@ -147,9 +147,9 @@ function getListOfMatches(uuid) {
           console.log(`${uuid} --> ${userId} --> :: `);
           console.log(rows);
           rows = rows.filter(row => {
-            return (row.opinion1 === 'UP' &&
+            return row.opinion1 === 'UP' &&
                    row.opinion2 === 'UP' &&
-                   row.firebaseChatId);
+                   row.firebaseChatId;
           });
           console.log(rows);
           // TODO: mitä pitäisi palauttaa
@@ -158,23 +158,25 @@ function getListOfMatches(uuid) {
     })
 };
 
+
 function closeMatch(close) {
-  
+
   return _uuidToUserId(close.uuid)
     .then(closerUserId => {
+      // """security check"""
       return knex('matches')
         .select('matches.*')
         .where({
-          'userId1': (closerUserId < close.matchedUserId) ? closerUserId : close.matchedUserId,
-          'userId2': (closerUserId < close.matchedUserId) ? close.matchedUserId : closerUserId,
+          'userId1': closerUserId < close.matchedUserId ? closerUserId : close.matchedUserId,
+          'userId2': closerUserId < close.matchedUserId ? close.matchedUserId : closerUserId,
           'firebaseChatId': close.firebaseChatId
         })
         .then(rows => {
           if (rows.length === 1) {
-            functionCore.closeChat(close.firebaseChatId);            
+            // this will close the chat via Firebase function
+            functionCore.closeChat(close.firebaseChatId);
           }
         })
-
     })
 };
 

--- a/src/http/match-http.js
+++ b/src/http/match-http.js
@@ -22,7 +22,16 @@ const postMatch = createJsonRoute(function(req, res) {
     .then(rows => undefined)
 })
 
+// this is used when a user closes a chat between another user
+const postMatchClose = createJsonRoute(function(req, res) {
+  const close = assert(req.body, 'matchClose');
+
+  return matchesCore.closeMatch(close)
+    .then(rows => undefined)
+})
+
 export {
   getMatches,
-  postMatch
+  postMatch,
+  postMatchClose
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -27,6 +27,7 @@ function createRouter() {
 
   router.get('/heila/matches/:uuid', matchHttp.getMatches);
   router.post('/heila/matches', matchHttp.postMatch);
+  router.post('/heila/matches/close', matchHttp.postMatchClose);
 
   router.get('/events', eventHttp.getEvents);
   router.get('/events/:id', eventHttp.getEvent);

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -46,6 +46,12 @@ const schemas = {
     opinion: Joi.string().regex(/^UP|DOWN$/).required()
   },
 
+  matchBan: {
+    uuid: common.userUuid.required(),
+    matchedUserId: common.primaryKeyId.required(),
+    firebaseChatId: Joi.string().required()
+  },
+
   matchesList: {
     uuid: common.userUuid.required(),
   },


### PR DESCRIPTION
This PR implements the closing of a chat between two users.

Notably:

* new endpoint /api/matches/close (accepts a POST)
* body of the POST documented in README
* new firebase function which handles the actual closing of the chat

How is the chat closed in practice? The function adds a new KV pair "closed": true into the chat object itself. Firebase security rules themselves control the read/write permissions of a particular chat so that if the value is closed, you cannot write anything to the chat.

(Note: the Firebase security rules will be provided out-of-git-band in a json format.)