### PR TITLE
Delete heila profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,10 @@ Responses:
 
 * Body is [heila bio object](#heila-bio-object).
 
+### `DELETE /api/heila/:uuid`
 
-
+> Deletes the heila profile AND switches the user profile's heila to false.
+  The user will also stop receiving any push notifications from the service.
 
 
 ### `POST /api/heila/matches`

--- a/functions/index.js
+++ b/functions/index.js
@@ -27,6 +27,42 @@ exports.addPushTokenForUserId = functions.https.onRequest((req, res) => {
 
 });
 
+
+// this function takes an userId as an argument and removes that user's 
+// pushToken from the database. after this the user will not receive any
+// push notifications from the service anymore.
+exports.removeUserId = functions.https.onRequest((req, res) => {
+
+  if (req.get('FUNCTION_SECRET_KEY') !== functions.config().functions.secret) {
+    console.log('not authenticated, FUNCTION_SECRET_KEY header is barps');
+    res.sendStatus(403);
+    return;
+  }
+
+  const userId = req.query.userId;
+
+  return admin.database().ref('/pushTokens/' + userId).set({ token: null }).then(snapshot => {
+    console.log('pushToken removed from userId ' + userId);
+    // return admin.database().ref('/chats/').once('value').then(snapshot => {
+    //   const allChats = snapshot.val();
+    //   const chatsToClose = [];
+    //   Object.keys(allChats).forEach(key => {
+    //     if (allChats[key].users[0] == userId || allChats[key].users[1] == userId) {
+    //       chatsToClose.push(key); 
+    //     }
+    //   });
+    //   // these are the keys for chats of this userId
+    //   // TODO: it should be decided what to do with them
+    //   // leave open, close them?
+    //   // should the other user be notified somehow?
+    //   console.log('chatsToClose:');
+    //   console.log(chatsToClose);
+    // });
+    res.sendStatus(200);
+  });
+
+});
+
 exports.addNewChatBetweenUsers = functions.https.onRequest((req, res) => {
   
   if (req.get('FUNCTION_SECRET_KEY') !== functions.config().functions.secret) {

--- a/src/core/function-core.js
+++ b/src/core/function-core.js
@@ -36,6 +36,22 @@ function addPushNotificationTokenForUserId(userId, pushToken) {
   })
 };
 
+function removeUserId(userId) {
+  console.log('removeUserIdFromChats ' + userId);
+  const current_url = `${BASE_URL}/removeUserId?userId=${userId}`;
+  console.log(current_url);
+  return fetch(current_url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'FUNCTION_SECRET_KEY': process.env.FUNCTION_SECRET_KEY
+    }
+  })
+  .catch(err => {
+    console.log(err);
+  })
+};
+
 function closeChatId(chatId) {
   console.log('closeChatId');
   const current_url = `${BASE_URL}/closeChatId?chatId=${chatId}`;
@@ -54,5 +70,6 @@ function closeChatId(chatId) {
 
 export {
   createChatForTwoUsers,
-  addPushNotificationTokenForUserId
+  addPushNotificationTokenForUserId,
+  removeUserId,
 }

--- a/src/core/match-core.js
+++ b/src/core/match-core.js
@@ -145,19 +145,17 @@ function getListOfMatches(uuid) {
         .orWhere('userId2', userId)
         .then(rows => {
           console.log(`${uuid} --> ${userId} --> :: `);
-          console.log(rows);
+          // console.log(rows);
           rows = rows.filter(row => {
             return row.opinion1 === 'UP' &&
                    row.opinion2 === 'UP' &&
                    row.firebaseChatId;
           });
-          console.log(rows);
-          // TODO: mitä pitäisi palauttaa
+          // console.log(rows);
           return rows;
         })
     })
 };
-
 
 function closeMatch(close) {
 

--- a/src/http/heila-http.js
+++ b/src/http/heila-http.js
@@ -3,6 +3,18 @@ import * as heilaCore from '../core/heila-core';
 import {throwStatus, createJsonRoute} from '../util/express';
 import {assert} from '../validation';
 
+const deleteHeila = createJsonRoute(function(req, res) {
+  const uuid = req.params.uuid; 
+  console.log('deleteHeila ' + uuid);
+  return heilaCore.deleteHeila(uuid)
+    .then(rowsInserted => undefined)
+    .catch(err => {
+      console.log('error happened while deleteHeila was called');
+      console.log(err);
+      throwStatus(500, 'Something went wrong.');
+    })
+});
+
 const putHeila = createJsonRoute(function(req, res) {
   console.log('putHeila');
   const heila = assert(req.body, 'heila');
@@ -51,5 +63,6 @@ const getHeilaTypes = createJsonRoute(function(req, res) {
 export {
   putHeila,
   getHeilaList,
-  getHeilaTypes
+  getHeilaTypes,
+  deleteHeila,
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -26,6 +26,7 @@ function createRouter() {
   router.get('/heila-types', heilaHttp.getHeilaTypes);
   // päivittää oman heilaprofiilin tekstikenttätietoja
   router.put('/heila/:uuid', heilaHttp.putHeila);
+  router.delete('/heila/:uuid', heilaHttp.deleteHeila);
 
   router.get('/heila/matches/:uuid', matchHttp.getMatches);
   router.post('/heila/matches', matchHttp.postMatch);


### PR DESCRIPTION
This PR adds the capability to DELETE a profile from the whappubuddy system.

Namely it:
* removes the user's profile row from the heila's table
* changes the user's profile's heila status to false
* removes the user's pushToken from Firebase so that no push notifications will be delivered anymore

Documentation updated accordingly.