### PR TITLE
Match notifications, read receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,15 @@ Responses:
 
 * Body is [heila report object](#heila-report-object).
 
+### `POST /api/heila-push-receipt`
+
+> Lets the push notification service know that the user has seen
+either a match notification or a msg notification and it's OK
+to send a new one. This should be called every time the user has cleared 
+the notifications.
+
+* Body is [push notification read receipt object](#push-notification-read-receipt-object).
+
 ### `PUT /api/heila/:uuid`
 
 > Update heila profile text fields.
@@ -583,8 +592,16 @@ When you're GETting your own list of matches:
   "text": "explanation for the report, required, max 500"
 }
 
+### Push notification read receipt object
+
+```js
+{
+  "uuid": "UUID",
+  "type": "match|msg" // depending on what was read
+}
 
 ```
+
 ### Event object
 
 ```js

--- a/functions/index.js
+++ b/functions/index.js
@@ -265,3 +265,24 @@ function updateReadReceiptAndSendPushNotification(userId, receiptType, payload) 
     });
 };
 
+exports.markRead = functions.https.onRequest((req, res) => {
+
+  // if (req.get('FUNCTION_SECRET_KEY') !== functions.config().functions.secret) {
+  //   console.log('not authenticated, FUNCTION_SECRET_KEY header is barps');
+  //   res.sendStatus(403);
+  //   return;
+  // }
+  
+  console.log(req.query);
+
+  const userId = req.query.userId;
+  const type = req.query.type;
+  const obj = {};
+  obj[type] = true;
+
+  return admin.database().ref(`/readReceipts/${userId}`)
+    .update(obj)
+    .then(r => {
+      console.log('readReceipt marked read');
+    });
+});

--- a/src/core/function-core.js
+++ b/src/core/function-core.js
@@ -68,8 +68,42 @@ function closeChatId(chatId) {
   })
 };
 
+function markRead(userId, type) {
+  console.log('markRead');
+  const current_url = `${BASE_URL}/markReadReceipt?userId=${userId}&type=${type}`;
+  console.log(current_url);
+  return fetch(current_url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'FUNCTION_SECRET_KEY': process.env.FUNCTION_SECRET_KEY
+    }
+  })
+  .catch(err => {
+    console.log(err);
+  })
+};
+
+function sendMatchNotification(userId1, userId2) {
+  console.log('sendMatchNotification');
+  const current_url = `${BASE_URL}/sendMatchNotification?userId1=${userId1}&userId2=${userId2}`;
+  console.log(current_url);
+  return fetch(current_url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'FUNCTION_SECRET_KEY': process.env.FUNCTION_SECRET_KEY
+    }
+  })
+  .catch(err => {
+    console.log(err);
+  })
+};
+
 export {
   createChatForTwoUsers,
   addPushNotificationTokenForUserId,
   removeUserId,
+  markRead,
+  sendMatchNotification,
 }

--- a/src/core/heila-core.js
+++ b/src/core/heila-core.js
@@ -257,7 +257,7 @@ function _heilaRowToObject(row) {
   }
 
   return {
-    id: row.id,
+    id: row.userId,
     uuid: row.uuid,
     // tässä asetetaan image_urli, jolla sen voi hakea verkosta ja näyttää
     // urlia ei oikeasti ole laitettu kantaan, siellä on vain image_path
@@ -310,6 +310,16 @@ function addHeilaReport(report) {
     });
 };
 
+function handleReadReceipt(receipt) {
+  console.log('handleReadReceipt');
+  
+  return findByUuid(receipt.uuid)
+    .then(rows => {
+      console.log(rows);
+      functionCore.markRead({ userId: rows.userId, type: receipt.type });
+    });
+};
+
 export {
   createOrUpdateHeila,
   findByUuid,
@@ -318,4 +328,5 @@ export {
   getHeilaTypes,
   deleteHeila,
   addHeilaReport,
+  handleReadReceipt,
 };

--- a/src/core/match-core.js
+++ b/src/core/match-core.js
@@ -133,6 +133,9 @@ function handleMatch(matchObject) {
         .where({ 'userId1': matchObject.userId1,
                  'userId2': matchObject.userId2 })
         .update(matchObject)
+        .then(rows => {
+          return funcionCore.sendMatchNofitication(matchObject.userId1, matchObject.userId2);
+        });
     })
 }
 

--- a/src/http/heila-http.js
+++ b/src/http/heila-http.js
@@ -74,10 +74,24 @@ const postHeilaReport = createJsonRoute(function(req, res) {
     });
 });
 
+const postPushNotificationReceipt = createJsonRoute(function(req, res) {
+  console.log('postPushNotificationReceipt');
+  const receipt = assert(req.body, 'heila_push_receipt');
+  console.log(receipt);
+
+  return heilaCore.handleReadReceipt(receipt)
+    .then(rowsInserted => {
+      if (rowsInserted === -1) {
+        throwStatus(500, 'Something went wrong.');
+      }
+    });
+});
+
 export {
   putHeila,
   getHeilaList,
   getHeilaTypes,
   deleteHeila,
   postHeilaReport,
+  postPushNotificationReceipt,
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,6 +25,7 @@ function createRouter() {
   router.get('/heila/:uuid', heilaHttp.getHeilaList);
   router.get('/heila-types', heilaHttp.getHeilaTypes);
   router.post('/heila-report', heilaHttp.postHeilaReport);
+  router.post('/heila-push-receipt', heilaHttp.postPushNotificationReceipt);
   // päivittää oman heilaprofiilin tekstikenttätietoja
   router.put('/heila/:uuid', heilaHttp.putHeila);
   router.delete('/heila/:uuid', heilaHttp.deleteHeila);

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -47,6 +47,11 @@ const schemas = {
     text: Joi.string().min(0, 'utf8').max(500, 'utf8').required(),
   },
 
+  heila_push_receipt: {
+    uuid: common.userUuid.required(),
+    type: Joi.string().regex(/^match|msg$/).required(),
+  },
+
   feedback: {
     uuid: common.userUuid.required(),
     id: common.primaryKeyId.required(),


### PR DESCRIPTION
This PR adds new functionality:

* new route, /api/heila-read-receipt
* new functions in firebase for handling read receipts and match notifications
* new logic to handle match notifications
* new logic to handle read receipts

Documentation is updated.

Client developers: you *HAVE TO* make a POST request to the new API *AFTER* the user clears the currently shown push messages.